### PR TITLE
Add GitHub Pages index

### DIFF
--- a/final_meal_prep_calendar.jsx
+++ b/final_meal_prep_calendar.jsx
@@ -41,7 +41,7 @@ const weekPlan = [
   { day: 'Freitag', meals: { breakfast: 2, lunch: 4, dinner: 6, snack: 3 } }
 ];
 
-export default function MealPrepCalendar() {
+function MealPrepCalendar() {
   const [expandedId, setExpandedId] = useState(null);
   const [scale, setScale] = useState(1);
 

--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Meal Prep Wochenplan</title>
+    <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+    <script src="https://unpkg.com/framer-motion/dist/framer-motion.umd.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="text/babel" src="final_meal_prep_calendar.jsx"></script>
+    <script type="text/babel">
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(<MealPrepCalendar />);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an `index.html` with CDN scripts so the app works on GitHub Pages
- remove the ES module export to allow the script to run in the browser

## Testing
- `node -v`
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_68506c884af08332b335e0b633d6c9c6